### PR TITLE
fix: clearing of routes

### DIFF
--- a/src/geo-map.ts
+++ b/src/geo-map.ts
@@ -17,6 +17,11 @@ export class GeoMap {
    */
   private implementation: Types.GeoMapImplementation;
 
+  /**
+   * @internal
+   */
+  private directionService: GeoMapDirectionService;
+
   public static create(init: {
     config: Types.GeoMapConfig;
     context?: Types.GeoMapContext;
@@ -190,7 +195,6 @@ export class GeoMap {
   private async getPlacesService(): Promise<GeoMapPlacesService> {
     await this.phase(Types.GeoMapPhase.Loaded);
 
-    // TODO: Move out of here when splitting GeoMap into Geo -> Map, Geo -> Code, Geo -> ...
     if (this.provider === Types.GeoMapProvider.Here) {
       const hereService = GeoMapPlacesService.create({
         type: this.provider as Types.GeoMapProvider.Here,
@@ -210,26 +214,30 @@ export class GeoMap {
   }
 
   private async getDirectionService(): Promise<GeoMapDirectionService> {
+    if (this.directionService) {
+      return this.directionService;
+    }
+
     await this.phase(Types.GeoMapPhase.Loaded);
 
     if (this.provider === Types.GeoMapProvider.Here) {
-      const hereService = GeoMapDirectionService.create({
+      this.directionService = GeoMapDirectionService.create({
         type: this.provider as Types.GeoMapProvider.Here,
         api: (this.implementation as GeoMapHere).api,
         platform: (this.implementation as GeoMapHere).platform,
         map: this.implementation
       });
 
-      return hereService;
+      return this.directionService;
     }
 
-    const googleService = GeoMapDirectionService.create({
+    this.directionService = GeoMapDirectionService.create({
       type: this.provider as Types.GeoMapProvider.Google,
       api: (this.implementation as GeoMapGoogle).api,
       map: this.implementation
     });
 
-    return googleService;
+    return this.directionService;
   }
 
   public async getPlace(

--- a/test/geo-map-google.test.ts
+++ b/test/geo-map-google.test.ts
@@ -256,21 +256,3 @@ test('paint route on google map', async () => {
   expect(data.end.lat).toBeCloseTo(Constants.S2_BER.lat);
   expect(data.end.lng).toBeCloseTo(Constants.S2_BER.lng);
 });
-
-test('paint route on here map', async () => {
-  await page.goto(`http://localhost:1338/?integration=true`);
-  await page.evaluate(() => TestEntry.Tests.paintHereRoute());
-
-  const data: GeoMapDirectionResult = JSON.parse(
-    String(
-      await page.evaluate(
-        () => document.querySelector('[data-dump="data-dump"]').textContent
-      )
-    )
-  );
-
-  expect(data.start.lat).toBeCloseTo(Constants.S2_HAM.lat);
-  expect(data.start.lng).toBeCloseTo(Constants.S2_HAM.lng);
-  expect(data.end.lat).toBeCloseTo(Constants.S2_BER.lat);
-  expect(data.end.lng).toBeCloseTo(Constants.S2_BER.lng);
-});

--- a/test/geo-map-here.test.ts
+++ b/test/geo-map-here.test.ts
@@ -235,3 +235,21 @@ test('getPlace with all details', async () => {
     })
   );
 });
+
+test('paint route on here map', async () => {
+  await page.goto(`http://localhost:1338/?integration=true`);
+  await page.evaluate(() => TestEntry.Tests.paintHereRoute());
+
+  const data: Types.GeoMapDirectionResult = JSON.parse(
+    String(
+      await page.evaluate(
+        () => document.querySelector('[data-dump="data-dump"]').textContent
+      )
+    )
+  );
+
+  expect(data.start.lat).toBeCloseTo(Constants.S2_HAM.lat);
+  expect(data.start.lng).toBeCloseTo(Constants.S2_HAM.lng);
+  expect(data.end.lat).toBeCloseTo(Constants.S2_BER.lat);
+  expect(data.end.lng).toBeCloseTo(Constants.S2_BER.lng);
+});


### PR DESCRIPTION
The direction service need to keep the drawings to remove them later on.
This results in a singleton statful service implementation.