### PR TITLE
fix: google marker not visible in IE11

### DIFF
--- a/src/test/create-google-mock.ts
+++ b/src/test/create-google-mock.ts
@@ -88,6 +88,10 @@ export const createGoogleMock = (): any => {
     }
   }
 
+  class GoogleMockSize {
+    /** */
+  }
+
   class GoogleMockMap {
     private el: HTMLElement;
 
@@ -182,6 +186,7 @@ export const createGoogleMock = (): any => {
     TransitLayer: GoogleMockLayer,
     TrafficLayer: GoogleMockLayer,
     Point: GoogleMockPoint,
-    Marker: GoogleMockMarker
+    Marker: GoogleMockMarker,
+    Size: GoogleMockSize
   };
 };


### PR DESCRIPTION
- fixes invalid SVG data URL for google marker
- adds marker size required by IE11
- unifies google marker config creation
