### PR TITLE
feat: retrieve GeoBounds from geocoder & center using GeoBounds

### DIFF
--- a/src/geo-map-coding-service-google.ts
+++ b/src/geo-map-coding-service-google.ts
@@ -17,6 +17,23 @@ export class GeoMapCodingServiceGoogle
     this.api = init.api;
   }
 
+  public geocode(search: Types.GeocoderRequest): Promise<Types.GeocoderResult> {
+    return new Promise((resolve, reject) => {
+      const geocoder = new this.api.Geocoder();
+
+      geocoder.geocode(
+        geocoderRequestToGoogleGeocoderRequest(search),
+        (results, status) => {
+          if (status === this.api.GeocoderStatus.OK) {
+            resolve(googleGeocoderResultToGeocoderResult(results[0]));
+          } else {
+            reject(status);
+          }
+        }
+      );
+    });
+  }
+
   public async reverse(
     location: Types.GeoPoint
   ): Promise<Types.Result<Types.GeoMapPlaceDetails[]>> {
@@ -34,6 +51,31 @@ export class GeoMapCodingServiceGoogle
       });
     });
   }
+}
+
+function geocoderRequestToGoogleGeocoderRequest(
+  search: Types.GeocoderRequest
+): google.maps.GeocoderRequest {
+  if (typeof search === 'string') {
+    return {
+      address: search
+    };
+  }
+
+  return {
+    componentRestrictions: {
+      country: search.country
+    }
+  };
+}
+
+function googleGeocoderResultToGeocoderResult(
+  result: google.maps.GeocoderResult
+): Types.GeocoderResult {
+  return {
+    position: result.geometry.location.toJSON(),
+    viewBounds: result.geometry.viewport.toJSON()
+  };
 }
 
 function googleToGeoPlace(

--- a/src/geo-map-coding-service.ts
+++ b/src/geo-map-coding-service.ts
@@ -52,6 +52,10 @@ export class GeoMapCodingService {
     this.implementation = init.implementation;
   }
 
+  public geocode(search: Types.GeocoderRequest): Promise<Types.GeocoderResult> {
+    return this.implementation.geocode(search);
+  }
+
   public async reverse(
     location: Types.GeoPoint
   ): Promise<Types.Result<Types.GeoMapPlaceDetails[]>> {

--- a/src/geo-map-here.ts
+++ b/src/geo-map-here.ts
@@ -3,6 +3,7 @@ import { GeoMarkerHere } from './geo-marker-here';
 import { GeoMapPhases } from './geo-map-phases';
 import { GeoRectHere } from './geo-rect-here';
 import { loadMapApi } from './load-map-api';
+import { isGeoPoint, isGeoBounds } from './util/type-guards';
 import * as Types from './types';
 
 export interface GeoMapHereInit {
@@ -93,8 +94,24 @@ export class GeoMapHere implements Types.GeoMapImplementation {
       }
     );
 
+    const bounds =
+      mountInit.center && isGeoBounds(mountInit.center)
+        ? new this.api.geo.Rect(
+            mountInit.center.north,
+            mountInit.center.west,
+            mountInit.center.south,
+            mountInit.center.east
+          )
+        : undefined;
+
+    const center =
+      mountInit.center && isGeoPoint(mountInit.center)
+        ? mountInit.center
+        : undefined;
+
     this.map = new api.Map(el, layer, {
-      center: mountInit.center,
+      center,
+      bounds,
       zoom: mountInit.zoom,
       noWrap: Boolean(this.config.noWrap)
     } as H.Map.Options);

--- a/src/geo-map.ts
+++ b/src/geo-map.ts
@@ -168,12 +168,9 @@ export class GeoMap {
   //   return this.implementation.coversLocation(point);
   // }
 
-  public async reverseGeocode(
-    point: Types.GeoPoint
-  ): Promise<Types.Result<Types.GeoMapPlaceDetails[]>> {
-    await this.phase(Types.GeoMapPhase.Loaded);
+  public async getGeocodingService(): Promise<GeoMapCodingService> {
+    await this.load();
 
-    // TODO: Move out of here when splitting GeoMap into Geo -> Map, Geo -> Code, Geo -> ...
     if (this.provider === Types.GeoMapProvider.Here) {
       const hereService = GeoMapCodingService.create({
         type: this.provider as Types.GeoMapProvider.Here,
@@ -181,7 +178,7 @@ export class GeoMap {
         platform: (this.implementation as GeoMapHere).platform
       });
 
-      return hereService.reverse(point);
+      return hereService;
     }
 
     const googleService = GeoMapCodingService.create({
@@ -189,7 +186,15 @@ export class GeoMap {
       api: (this.implementation as GeoMapGoogle).api
     });
 
-    return googleService.reverse(point);
+    return googleService;
+  }
+
+  public async reverseGeocode(
+    point: Types.GeoPoint
+  ): Promise<Types.Result<Types.GeoMapPlaceDetails[]>> {
+    const service = await this.getGeocodingService();
+    const result = await service.reverse(point);
+    return result;
   }
 
   private async getPlacesService(): Promise<GeoMapPlacesService> {

--- a/src/here-types.ts
+++ b/src/here-types.ts
@@ -163,6 +163,16 @@ interface LatLng {
   longitude: number;
 }
 
+export interface GeocoderLatLng {
+  Latitude: number;
+  Longitude: number;
+}
+
+export interface GeocoderLatLngBounds {
+  BottomRight: GeocoderLatLng;
+  TopLeft: GeocoderLatLng;
+}
+
 export type Country =
   | 'ABW'
   | 'AFG'

--- a/src/types/geo-map.ts
+++ b/src/types/geo-map.ts
@@ -193,8 +193,10 @@ export interface GeoPoint {
   lng: number;
 }
 
+export type GeoMapCenter = GeoPoint | GeoBounds;
+
 export interface GeoMapMountInit {
-  center: GeoPoint;
+  center?: GeoMapCenter;
   type?: GeoMapType;
   layer?: GeoLayer;
   zoom?: number;

--- a/src/types/geo-map.ts
+++ b/src/types/geo-map.ts
@@ -396,8 +396,21 @@ export type GeoEventHandler<T extends GeoEventPayload | void = any> = (
   e?: T
 ) => void;
 
+export interface GeocoderResult {
+  position: GeoPoint;
+  viewBounds: GeoBounds;
+}
+
+export interface StructuredGeocoderRequest {
+  /** ISO 3166 Alpha-2 Country Code */
+  country?: string;
+}
+
+export type GeocoderRequest = string | StructuredGeocoderRequest;
+
 export interface GeoMapCodingServiceImplementation {
   reverse(point: GeoPoint): Promise<Types.Result<GeoMapPlaceDetails[]>>;
+  geocode(search: GeocoderRequest): Promise<GeocoderResult>;
 }
 
 export interface GeoMapDirectionResult {

--- a/src/util/type-guards.ts
+++ b/src/util/type-guards.ts
@@ -1,0 +1,18 @@
+import * as Types from '../types';
+
+export function isGeoBounds(value: {}): value is Types.GeoBounds {
+  const geoBounds = value as Partial<Types.GeoBounds>;
+
+  return (
+    typeof geoBounds.east === 'number' &&
+    typeof geoBounds.north === 'number' &&
+    typeof geoBounds.south === 'number' &&
+    typeof geoBounds.west === 'number'
+  );
+}
+
+export function isGeoPoint(value: {}): value is Types.GeoPoint {
+  const geoPoint = value as Partial<Types.GeoPoint>;
+
+  return typeof geoPoint.lat === 'number' && typeof geoPoint.lng === 'number';
+}


### PR DESCRIPTION
This PR adds the following features

- centering the map by providing `GeoPoint | GeoBounds` as center parameter when using `mount()`
- expose the geocoding service
- add geocoding functionality to the geocoding service (returns position & viewBounds for a given search)